### PR TITLE
Ignore non-pdb files in pdb2seq.py

### DIFF
--- a/docs/data_curation/pdb2seq.py
+++ b/docs/data_curation/pdb2seq.py
@@ -15,7 +15,7 @@ def pdb2seq(pdbf):
 
 
 if __name__=="__main__":
-    list_of_pdb_with_cavity_center = [l for l in os.listdir("PDB_CHAINS")]
+    list_of_pdb_with_cavity_center = [l for l in os.listdir("PDB_CHAINS") if l.endswith(".pdb")]]
     os.system("mkdir PROFILES")
     for pdbf in list_of_pdb_with_cavity_center:
         pdb2seq(pdbf)


### PR DESCRIPTION
Following the readme of data_curation, 
`pdb2seq.py` in 4. Convert PDB to FASTA fails.
This is because `pdb2seq.py` reads all files including .pops file generated before, which is fixed by this PR.